### PR TITLE
Add warning message for Python API

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,13 +42,13 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
           ls -ls /Applications/
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
-          echo "::set-env name=CC::clang"
-          echo "::set-env name=CXX::clang++"
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
           # Ubuntu 16.04 + gcc-7
-          - name: "Ubuntu 16.04 + gcc-7"
-            os: ubuntu-16.04
-            compiler: gcc
-            version: "7"
+          #- name: "Ubuntu 16.04 + gcc-7"
+          #  os: ubuntu-16.04
+          #  compiler: gcc
+          #  version: "7"
           # Ubuntu 18.04 + gcc-8
           - name: "Ubuntu 18.04 + gcc-8"
             os: ubuntu-18.04
@@ -27,10 +27,10 @@ jobs:
             compiler: gcc
             version: "9"
           # Ubuntu 16.04 + clang-8
-          - name: "Ubuntu 16.04 + clang-8"
-            os: ubuntu-16.04
-            compiler: clang
-            version: "8"
+          #- name: "Ubuntu 16.04 + clang-8"
+          #  os: ubuntu-16.04
+          #  compiler: clang
+          #  version: "8"
           # Ubuntu 18.04 + clang-9
           - name: "Ubuntu 18.04 + clang-9"
             os: ubuntu-18.04

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -54,11 +54,11 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
-          echo "::set-env name=CC::clang-${{ matrix.version }}"
-          echo "::set-env name=CXX::clang++-${{ matrix.version }}"
+          echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..

--- a/.github/workflows/ubuntu_codecov.yml
+++ b/.github/workflows/ubuntu_codecov.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Configure Compiler
       run: |
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-          echo "::set-env name=CC::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX::g++-${{ matrix.version }}"
+          echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
-          echo "::set-env name=CC::clang-${{ matrix.version }}"
-          echo "::set-env name=CXX::clang++-${{ matrix.version }}"
+          echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
         fi
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_COVERAGE=ON ..

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Configure Build
       run: mkdir build && cd build && cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Release ..
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Build
       run: cd build && MSBuild.exe CubbyFlow.sln /p:Configuration=Release
     - name: Run Unit Test

--- a/Documents/Install.md
+++ b/Documents/Install.md
@@ -298,6 +298,24 @@ pytest Tests/PythonTests
 
 The tests should pass.
 
+> Warning: When you run Python examples using Intel TBB from Windows, you might encounter the following error:
+
+```
+import pyCubbyFlow
+ImportError: DLL load failed while importing pyCubbyFlow:
+The specified module could not be found. 
+```
+
+> It is a new Windows safety feature that changes how DLLs are loaded in Python 3.8+. To resolve this issue, I needed to tell Python how to find the library again like this:
+
+```
+import os
+os.add_dll_directory(r'C:/Intel/tbb/bin/intel64/vc14') << (The path that Intel TBB is located)
+import pyCubbyFlow
+```
+
+> Open example file and add the code above to the first line. Now, you won't have any problems running it.
+
 ### Coding Style
 
 CubbyFlow uses clang-format. Checkout [`.clang-format`](https://github.com/utilforever/CubbyFlow/blob/master/.clang-format) file for the style guideline.


### PR DESCRIPTION
This revision includes:
- Add warning message for Python API (#72)
  - Python API import error on Windows and Python 3.8+ with Intel TBB
- Update commands by Github Actions policy
  - The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/