### PR TITLE
Correct the logic of method 'call()' in struct 'Cubic'

### DIFF
--- a/Includes/Core/Array/ArraySamplers-Impl.hpp
+++ b/Includes/Core/Array/ArraySamplers-Impl.hpp
@@ -455,7 +455,7 @@ T CubicArraySampler<T, N, CIOp>::operator()(const VectorType& pt) const
 
     for (size_t i = 0; i < N; ++i)
     {
-        GetBarycentric(npt[i], 0, size[i] - 1, is[i], ts[i]);
+        GetBarycentric(npt[i], 0, size[i], is[i], ts[i]);
     }
 
     return Internal::Cubic<T, N, N>::Call(m_view, is, ts, CIOp());

--- a/Includes/Core/Array/ArraySamplers-Impl.hpp
+++ b/Includes/Core/Array/ArraySamplers-Impl.hpp
@@ -62,12 +62,13 @@ struct Cubic
         using Next = Cubic<T, N, I - 1>;
 
         return op(
-            Next::Call(view, i, t, op,
-                       std::max(i[I - 1] - 1,
-                                static_cast<ssize_t>(view.Size()[I - 1]) - 1),
+            Next::Call(view, i, t, op, std::max(i[I - 1] - 1, ZERO_SSIZE),
                        indices...),
             Next::Call(view, i, t, op, i[I - 1], indices...),
-            Next::Call(view, i, t, op, i[I - 1] + 1, indices...),
+            Next::Call(view, i, t, op,
+                       std::min(i[I - 1] + 1,
+                                static_cast<ssize_t>(view.Size()[I - 1]) - 1),
+                       indices...),
             Next::Call(view, i, t, op,
                        std::min(i[I - 1] + 2,
                                 static_cast<ssize_t>(view.Size()[I - 1]) - 1),
@@ -88,9 +89,10 @@ struct Cubic<T, N, 1>
                      RemainingIndices... indices)
     {
         return op(
-            view(std::max(i[0] - 1, static_cast<ssize_t>(view.Size()[0]) - 1),
+            view(std::max(i[0] - 1, ZERO_SSIZE), indices...),
+            view(i[0], indices...),
+            view(std::min(i[0] + 1, static_cast<ssize_t>(view.Size()[0]) - 1),
                  indices...),
-            view(i[0], indices...), view(i[0] + 1, indices...),
             view(std::min(i[0] + 2, static_cast<ssize_t>(view.Size()[0]) - 1),
                  indices...),
             t[0]);
@@ -453,7 +455,7 @@ T CubicArraySampler<T, N, CIOp>::operator()(const VectorType& pt) const
 
     for (size_t i = 0; i < N; ++i)
     {
-        GetBarycentric(npt[i], 0, size[i], is[i], ts[i]);
+        GetBarycentric(npt[i], 0, size[i] - 1, is[i], ts[i]);
     }
 
     return Internal::Cubic<T, N, N>::Call(m_view, is, ts, CIOp());


### PR DESCRIPTION
This revision includes:
- Correct the logic code in 'Cubic::Call()' (#99), (#100)