### PR TITLE
Fix Quaternion SLerp Implementation

### DIFF
--- a/Includes/Core/Math/Quaternion-Impl.hpp
+++ b/Includes/Core/Math/Quaternion-Impl.hpp
@@ -266,7 +266,7 @@ Quaternion<T> Quaternion<T>::Mul(const Quaternion& other) const
 }
 
 template <typename T>
-T Quaternion<T>::Dot(const Quaternion<T>& other)
+T Quaternion<T>::Dot(const Quaternion<T>& other) const
 {
     return w * other.w + x * other.x + y * other.y + z * other.z;
 }

--- a/Includes/Core/Math/Quaternion-Impl.hpp
+++ b/Includes/Core/Math/Quaternion-Impl.hpp
@@ -505,7 +505,7 @@ Quaternion<T> Slerp(const Quaternion<T>& a, const Quaternion<T>& b, T t)
     static const double threshold = 0.01;
     static const T eps = std::numeric_limits<T>::epsilon();
 
-    T cosHalfAngle = dot(a, b);
+    T cosHalfAngle = a.Dot(b);
     T weightA, weightB;
 
     // For better accuracy, return lerp result when a and b are close enough.

--- a/Includes/Core/Math/Quaternion.hpp
+++ b/Includes/Core/Math/Quaternion.hpp
@@ -99,7 +99,7 @@ class Quaternion
     [[nodiscard]] Quaternion Mul(const Quaternion& other) const;
 
     //! Computes the dot product with other quaternion.
-    [[nodiscard]] T Dot(const Quaternion<T>& other);
+    [[nodiscard]] T Dot(const Quaternion<T>& other) const;
 
     //! Returns other quaternion * this quaternion.
     [[nodiscard]] Quaternion RMul(const Quaternion& other) const;

--- a/Tests/UnitTests/QuaternionTests.cpp
+++ b/Tests/UnitTests/QuaternionTests.cpp
@@ -216,6 +216,37 @@ TEST(Quaternion, BinaryOperators)
     EXPECT_EQ(q3, q1);
 }
 
+TEST(Quaternion, Slerp)
+{
+    QuaternionD q1( 1.0f, 0.0f, 1.0f, 0.0f);
+    QuaternionD q2(-1.0f, 0.0f, 1.0f, 0.0f);
+
+    {
+        QuaternionD q = Slerp(q1, q2, 0.0);
+
+        EXPECT_DOUBLE_EQ(q1.x, q.x);
+        EXPECT_DOUBLE_EQ(q1.y, q.y);
+        EXPECT_DOUBLE_EQ(q1.z, q.z);
+        EXPECT_DOUBLE_EQ(q1.w, q.w);
+    }
+    {
+        QuaternionD q = Slerp(q1, q2, 1.0);
+
+        EXPECT_DOUBLE_EQ(q2.x, q.x);
+        EXPECT_DOUBLE_EQ(q2.y, q.y);
+        EXPECT_DOUBLE_EQ(q2.z, q.z);
+        EXPECT_DOUBLE_EQ(q2.w, q.w);
+    }
+    {
+        QuaternionD q = Slerp(q1, q2, 0.5);
+
+        EXPECT_DOUBLE_EQ(0.0, q.x);
+        EXPECT_DOUBLE_EQ(1.414213562373095, q.y);
+        EXPECT_DOUBLE_EQ(0.0, q.z);
+        EXPECT_DOUBLE_EQ(0.0, q.w);
+    }
+}
+
 TEST(Quaternion, Modifiers)
 {
     QuaternionD q(4, 3, 2, 1);


### PR DESCRIPTION
### Known Issues
* Compile error in Slerp implementation `[ msvc 19.29.30040 x64 ]`

### Changes

#### 1. Modify Dot method misuse
##### Before
```c++
T cosHalfAngle = dot(a, b);
```
##### After
```c++
T cosHalfAngle = a.Dot(b);
```

#### 2. Add const keyword to Quaternion::Dot method
```c++
[[nodiscard]] T Dot(const Quaternion<T>& other) const;
```

#### 3. Add Unit-test code for quaternion slerp
```c++
TEST(Quaternion, Slerp)
{
    QuaternionD q1( 1.0f, 0.0f, 1.0f, 0.0f);
    QuaternionD q2(-1.0f, 0.0f, 1.0f, 0.0f);

    {
        QuaternionD q = Slerp(q1, q2, 0.0);

        EXPECT_DOUBLE_EQ(q1.x, q.x);
        EXPECT_DOUBLE_EQ(q1.y, q.y);
        EXPECT_DOUBLE_EQ(q1.z, q.z);
        EXPECT_DOUBLE_EQ(q1.w, q.w);
    }
    {
        QuaternionD q = Slerp(q1, q2, 1.0);

        EXPECT_DOUBLE_EQ(q2.x, q.x);
        EXPECT_DOUBLE_EQ(q2.y, q.y);
        EXPECT_DOUBLE_EQ(q2.z, q.z);
        EXPECT_DOUBLE_EQ(q2.w, q.w);
    }
    {
        QuaternionD q = Slerp(q1, q2, 0.5);

        EXPECT_DOUBLE_EQ(0.0, q.x);
        EXPECT_DOUBLE_EQ(1.414213562373095, q.y);
        EXPECT_DOUBLE_EQ(0.0, q.z);
        EXPECT_DOUBLE_EQ(0.0, q.w);
    }
}
```

### References
* https://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/index.htm