### PR TITLE
Upgrade Windows build for GitHub Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,9 @@ jobs:
           # Windows Server 2019 + Visual Studio 2019
           - name: "Windows Server 2019 + Visual Studio 2019"
             os: windows-2019
+          # Windows Server 2022 + Visual Studio 2022
+          - name: "Windows Server 2022 + Visual Studio 2022"
+            os: windows-2022
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
This revision includes:
- Upgrade Windows build for GitHub Actions (Resolves #123)
  - Add "Windows Server 2022 + Visual Studio 2022"