### PR TITLE
Replace code to call 'GetSmokeDensity()' with 'GetTemperature()'

### DIFF
--- a/Sources/Core/Solver/Grid/GridSmokeSolver2.cpp
+++ b/Sources/Core/Solver/Grid/GridSmokeSolver2.cpp
@@ -132,7 +132,7 @@ void GridSmokeSolver2::ComputeDiffusion(double timeIntervalInSeconds)
         if (m_temperatureDiffusionCoefficient >
             std::numeric_limits<double>::epsilon())
         {
-            const ScalarGrid2Ptr temp = GetSmokeDensity();
+            const ScalarGrid2Ptr temp = GetTemperature();
             const std::shared_ptr<CellCenteredScalarGrid2> temp0 =
                 std::dynamic_pointer_cast<CellCenteredScalarGrid2>(
                     temp->Clone());

--- a/Sources/Core/Solver/Grid/GridSmokeSolver3.cpp
+++ b/Sources/Core/Solver/Grid/GridSmokeSolver3.cpp
@@ -132,7 +132,7 @@ void GridSmokeSolver3::ComputeDiffusion(double timeIntervalInSeconds)
         if (m_temperatureDiffusionCoefficient >
             std::numeric_limits<double>::epsilon())
         {
-            const ScalarGrid3Ptr temp = GetSmokeDensity();
+            const ScalarGrid3Ptr temp = GetTemperature();
             const std::shared_ptr<CellCenteredScalarGrid3> temp0 =
                 std::dynamic_pointer_cast<CellCenteredScalarGrid3>(
                     temp->Clone());

--- a/Tests/UnitTests/GridSmokeSolver2Tests.cpp
+++ b/Tests/UnitTests/GridSmokeSolver2Tests.cpp
@@ -1,0 +1,15 @@
+#include "gtest/gtest.h"
+
+#include <Core/Solver/Grid/GridSmokeSolver2.hpp>
+
+using namespace CubbyFlow;
+
+TEST(GridSmokeSolver2, UpdateEmpty)
+{
+    GridSmokeSolver2 solver;
+
+    for (Frame frame; frame.index < 2; ++frame)
+    {
+        solver.Update(frame);
+    }
+}

--- a/Tests/UnitTests/GridSmokeSolver3Tests.cpp
+++ b/Tests/UnitTests/GridSmokeSolver3Tests.cpp
@@ -1,0 +1,15 @@
+#include "gtest/gtest.h"
+
+#include <Core/Solver/Grid/GridSmokeSolver3.hpp>
+
+using namespace CubbyFlow;
+
+TEST(GridSmokeSolver3, UpdateEmpty)
+{
+    GridSmokeSolver3 solver;
+
+    for (Frame frame; frame.index < 2; ++frame)
+    {
+        solver.Update(frame);
+    }
+}


### PR DESCRIPTION
This revision includes:
- Replace code to call 'GetSmokeDensity()' with 'GetTemperature()' (Resolves #129)