### PR TITLE
Restore SonarCloud

### DIFF
--- a/.github/workflows/scripts/actions/install_cuda_ubuntu.sh
+++ b/.github/workflows/scripts/actions/install_cuda_ubuntu.sh
@@ -26,13 +26,13 @@ CUDA_PACKAGES_IN=(
 ## -------------------
 # returns 0 (true) if a >= b
 function version_ge() {
-    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
-    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]
+    [[ "$#" != "2" ]] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$2" ]]
 }
 # returns 0 (true) if a > b
 function version_gt() {
-    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
-    if [ "$1" = "$2" ]
+    [[ "$#" != "2" ]] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    if [[ "$1" = "$2" ]]
     then
       return 1
     else
@@ -41,13 +41,13 @@ function version_gt() {
 }
 # returns 0 (true) if a <= b
 function version_le() {
-    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
-    [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]
+    [[ "$#" != "2" ]] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    [[ "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "$1" ]]
 }
 # returns 0 (true) if a < b
 function version_lt() {
-    [ "$#" != "2" ] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
-    if [ "$1" = "$2" ]
+    [[ "$#" != "2" ]] && echo "${FUNCNAME[0]} requires exactly 2 arguments." && exit 1
+    if [[ "$1" = "$2" ]]
     then
       return 1
     else
@@ -78,16 +78,16 @@ echo "CUDA_PATCH: ${CUDA_PATCH}"
 echo "UBUNTU_VERSION: ${UBUNTU_VERSION}"
 
 # If we don't know the CUDA_MAJOR or MINOR, error.
-if [ -z "${CUDA_MAJOR}" ] ; then
+if [[ -z "${CUDA_MAJOR}" ]] ; then
     echo "Error: Unknown CUDA Major version. Aborting."
     exit 1
 fi
-if [ -z "${CUDA_MINOR}" ] ; then
+if [[ -z "${CUDA_MINOR}" ]] ; then
     echo "Error: Unknown CUDA Minor version. Aborting."
     exit 1
 fi
 # If we don't know the Ubuntu version, error.
-if [ -z ${UBUNTU_VERSION} ]; then
+if [[ -z "${UBUNTU_VERSION}" ]]; then
     echo "Error: Unknown Ubuntu version. Aborting."
     exit 1
 fi

--- a/.github/workflows/ubuntu-sonarcloud.yml
+++ b/.github/workflows/ubuntu-sonarcloud.yml
@@ -53,9 +53,9 @@ jobs:
         run: |
           cd build
           GCOV_TOOL="$(command -v gcov-${{ matrix.version }})"
-          lcov --gcov-tool "${GCOV_TOOL}" -c -i -d Tests/UnitTests -o base.info
+          lcov --gcov-tool "${GCOV_TOOL}" --ignore-errors mismatch -c -i -d Tests/UnitTests -o base.info
           bin/UnitTests
-          lcov --gcov-tool "${GCOV_TOOL}" -c -d Tests/UnitTests -o test.info
+          lcov --gcov-tool "${GCOV_TOOL}" --ignore-errors mismatch -c -d Tests/UnitTests -o test.info
           lcov --gcov-tool "${GCOV_TOOL}" -a base.info -a test.info -o coverage.info
           lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" -r coverage.info '*/Includes/*' -o coverage.info
           lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" -r coverage.info '*/Libraries/*' -o coverage.info

--- a/.github/workflows/ubuntu-sonarcloud.yml
+++ b/.github/workflows/ubuntu-sonarcloud.yml
@@ -25,11 +25,11 @@ jobs:
           fetch-depth: 0
       - name: Prepare Sonar scanner
         run: |
-          wget -nv https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.0.1.6346-linux-x64.zip
+          wget -nv --max-redirect=0 https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.0.1.6346-linux-x64.zip
           unzip -q sonar-scanner-cli-8.0.1.6346-linux-x64.zip
           SONAR_SCANNER_DIR="$(echo sonar-scanner-*-linux-x64)"
           echo "${PWD}/${SONAR_SCANNER_DIR}/bin" >> $GITHUB_PATH
-          wget -nv https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+          wget -nv --max-redirect=0 https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
           unzip -q build-wrapper-linux-x86.zip
           echo "${PWD}/build-wrapper-linux-x86" >> $GITHUB_PATH
       - name: Install packages

--- a/.github/workflows/ubuntu-sonarcloud.yml
+++ b/.github/workflows/ubuntu-sonarcloud.yml
@@ -1,64 +1,67 @@
-# name: Ubuntu - SonarCloud
+name: Static Analysis
 
-# on:
-#   push:
-#     branches: [ main ]
-#   pull_request:
-#     branches: [ main ]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
-# jobs:
-#   build-ubuntu:
-#     runs-on: ${{ matrix.os }}
-#     name: ${{ matrix.name }}
-#     strategy:
-#       matrix:
-#         include:
-#           # Ubuntu 20.04 + gcc-9
-#           - name: "Ubuntu 20.04 + gcc-9"
-#             os: ubuntu-20.04
-#             compiler: gcc
-#             version: "9"
-#     steps:
-#     - uses: actions/checkout@v2
-#       with:
-#         submodules: true
-#     - name: Prepare Sonar scanner
-#       run: |
-#         wget -nv https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.6.0.2311-linux.zip
-#         unzip -q sonar-scanner-cli-4.6.0.2311-linux.zip
-#         echo "${PWD}/sonar-scanner-4.6.0.2311-linux/bin/" >> $GITHUB_PATH
-#         wget -nv https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
-#         unzip -q build-wrapper-linux-x86.zip
-#         echo "${PWD}/build-wrapper-linux-x86" >> $GITHUB_PATH
-#     - name: Install packages
-#       run: sudo apt-get install -yq gcovr ggcov lcov curl
-#     - name: Configure Compiler
-#       run: |
-#         if [ "${{ matrix.compiler }}" = "gcc" ]; then
-#           echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
-#           echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
-#         else
-#           echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
-#           echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
-#         fi
-#     - name: Configure Build
-#       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_COVERAGE=ON -DBUILD_SONARCLOUD=ON ..
-#     - name: Build
-#       run: cd build && build-wrapper-linux-x86-64 --out-dir ../bw-output make all
-#     - name: Run Unit Test
-#       run: |
-#         cd build
-#         lcov --gcov-tool /usr/bin/gcov -c -i -d Tests/UnitTests -o base.info
-#         bin/UnitTests
-#         lcov --gcov-tool /usr/bin/gcov -c -d Tests/UnitTests -o test.info
-#         lcov --gcov-tool /usr/bin/gcov -a base.info -a test.info -o coverage.info
-#         lcov --gcov-tool /usr/bin/gcov -r coverage.info '/usr/*' -o coverage.info
-#         lcov --gcov-tool /usr/bin/gcov -r coverage.info '*/Examples/*' -o coverage.info
-#         lcov --gcov-tool /usr/bin/gcov -r coverage.info '*/Libraries/*' -o coverage.info
-#         lcov --gcov-tool /usr/bin/gcov -r coverage.info '*/Tests/*' -o coverage.info
-#         lcov --gcov-tool /usr/bin/gcov -l coverage.info
-#     - name: SonarCloud Scan
-#       run: sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=cubbyflow -Dsonar.login=$SONAR_TOKEN
-#       env:
-#         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+jobs:
+  build-ubuntu:
+    runs-on: ${{ matrix.os }}
+    name: 🌞 Static Analysis - SonarCloud
+    strategy:
+      matrix:
+        include:
+          # Ubuntu 24.04 + gcc-14
+          - name: "Ubuntu 24.04 + gcc-14"
+            os: ubuntu-24.04
+            compiler: gcc
+            version: "14"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Prepare Sonar scanner
+        run: |
+          wget -nv https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-8.0.1.6346-linux-x64.zip
+          unzip -q sonar-scanner-cli-8.0.1.6346-linux-x64.zip
+          SONAR_SCANNER_DIR="$(echo sonar-scanner-*-linux-x64)"
+          echo "${PWD}/${SONAR_SCANNER_DIR}/bin" >> $GITHUB_PATH
+          wget -nv https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+          unzip -q build-wrapper-linux-x86.zip
+          echo "${PWD}/build-wrapper-linux-x86" >> $GITHUB_PATH
+      - name: Install packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq lcov curl
+      - name: Configure Compiler
+        run: |
+          if [ "${{ matrix.compiler }}" = "gcc" ]; then
+            echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+            echo "CXX=g++-${{ matrix.version }}" >> $GITHUB_ENV
+          else
+            echo "CC=clang-${{ matrix.version }}" >> $GITHUB_ENV
+            echo "CXX=clang++-${{ matrix.version }}" >> $GITHUB_ENV
+          fi
+      - name: Configure Build
+        run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_COVERAGE=ON -DBUILD_SONARCLOUD=ON ..
+      - name: Build
+        run: cd build && build-wrapper-linux-x86-64 --out-dir ../bw-output make all
+      - name: Run Unit Test
+        run: |
+          cd build
+          GCOV_TOOL="$(command -v gcov-${{ matrix.version }})"
+          lcov --gcov-tool "${GCOV_TOOL}" -c -i -d Tests/UnitTests -o base.info
+          bin/UnitTests
+          lcov --gcov-tool "${GCOV_TOOL}" -c -d Tests/UnitTests -o test.info
+          lcov --gcov-tool "${GCOV_TOOL}" -a base.info -a test.info -o coverage.info
+          lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" -r coverage.info '*/Includes/*' -o coverage.info
+          lcov --ignore-errors unused --gcov-tool "${GCOV_TOOL}" -r coverage.info '*/Libraries/*' -o coverage.info
+          lcov --gcov-tool "${GCOV_TOOL}" -l coverage.info
+      - name: SonarCloud Scan
+        run: sonar-scanner -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=utilforever-github -Dsonar.login=$SONAR_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,3 @@
+sonar.sources=.github,Includes,Sources,Tests
+sonar.exclusions=Sources/Core/Flatbuffers/generated/**
+sonar.cfamily.reportingCppStandardOverride=c++17

--- a/Includes/Core/Matrix/Matrix.hpp
+++ b/Includes/Core/Matrix/Matrix.hpp
@@ -348,32 +348,13 @@ class Matrix<T, 3, 1> final : public MatrixExpression<T, 3, 1, Matrix<T, 3, 1>>,
 
     ~Matrix() = default;
 
-    constexpr Matrix(const Matrix& other) : x(other.x), y(other.y), z(other.z)
-    {
-        // Do nothing
-    }
+    constexpr Matrix(const Matrix&) = default;
 
-    constexpr Matrix(Matrix&& other) noexcept
-        : x(std::move(other.x)), y(std::move(other.y)), z(std::move(other.z))
-    {
-        // Do nothing
-    }
+    constexpr Matrix(Matrix&&) noexcept = default;
 
-    Matrix& operator=(const Matrix& other)
-    {
-        x = other.x;
-        y = other.y;
-        z = other.z;
-        return *this;
-    }
+    Matrix& operator=(const Matrix&) = default;
 
-    Matrix& operator=(Matrix&& other) noexcept
-    {
-        x = std::move(other.x);
-        y = std::move(other.y);
-        z = std::move(other.z);
-        return *this;
-    }
+    Matrix& operator=(Matrix&&) noexcept = default;
 
     void Fill(const T& val);
 

--- a/Includes/Core/Utils/Logging.hpp
+++ b/Includes/Core/Utils/Logging.hpp
@@ -57,7 +57,7 @@ class Logger final
 
     //! Writes a value to the buffer stream.
     template <typename T>
-    const Logger& operator<<(const T& x) const
+    Logger& operator<<(const T& x)
     {
         m_buffer << x;
         return *this;
@@ -65,7 +65,7 @@ class Logger final
 
  private:
     LogLevel m_level;
-    mutable std::stringstream m_buffer{};
+    std::stringstream m_buffer{};
 };
 
 //! Helper class for logging.

--- a/Includes/Core/Utils/Serialization-Impl.hpp
+++ b/Includes/Core/Utils/Serialization-Impl.hpp
@@ -12,12 +12,16 @@
 #define CUBBYFLOW_SERIALIZATION_IMPL_HPP
 
 #include <cstring>
+#include <stdexcept>
+#include <type_traits>
 
 namespace CubbyFlow
 {
 template <typename T>
 void Serialize(const ConstArrayView1<T>& array, std::vector<uint8_t>* buffer)
 {
+    static_assert(std::is_trivially_copyable_v<T>);
+
     const size_t size = sizeof(T) * array.Length();
     Serialize(reinterpret_cast<const uint8_t*>(array.data()), size, buffer);
 }
@@ -25,8 +29,18 @@ void Serialize(const ConstArrayView1<T>& array, std::vector<uint8_t>* buffer)
 template <typename T>
 void Deserialize(const std::vector<uint8_t>& buffer, Array1<T>* array)
 {
+    static_assert(std::is_trivially_copyable_v<T>);
+
     std::vector<uint8_t> data;
     Deserialize(buffer, &data);
+
+    if (data.size() % sizeof(T) != 0)
+    {
+        throw std::invalid_argument{
+            "Serialized data size must be a multiple of the element size."
+        };
+    }
+
     array->Resize(data.size() / sizeof(T));
     std::memcpy(array->data(), data.data(), data.size());
 }

--- a/Sources/Core/Utils/Serialization.cpp
+++ b/Sources/Core/Utils/Serialization.cpp
@@ -12,6 +12,7 @@
 
 #include <Flatbuffers/generated/FlatData_generated.h>
 
+#include <stdexcept>
 #include <vector>
 
 namespace CubbyFlow
@@ -26,7 +27,9 @@ void Serialize(const uint8_t* data, size_t size, std::vector<uint8_t>* buffer)
     flatbuffers::FlatBufferBuilder builder(1024);
 
     const auto fbsData =
-        fbs::CreateFlatData(builder, builder.CreateVector(data, size));
+        (size == 0)
+            ? fbs::CreateFlatData(builder)
+            : fbs::CreateFlatData(builder, builder.CreateVector(data, size));
 
     builder.Finish(fbsData);
 
@@ -44,8 +47,27 @@ void Deserialize(const std::vector<uint8_t>& buffer, Serializable* serializable)
 
 void Deserialize(const std::vector<uint8_t>& buffer, std::vector<uint8_t>* data)
 {
+    if (buffer.empty())
+    {
+        throw std::invalid_argument{ "Invalid serialized data." };
+    }
+
+    flatbuffers::Verifier verifier(buffer.data(), buffer.size());
+
+    if (!fbs::VerifyFlatDataBuffer(verifier))
+    {
+        throw std::invalid_argument{ "Invalid serialized data." };
+    }
+
     const auto fbsData = fbs::GetFlatData(buffer.data());
-    data->resize(fbsData->data()->size());
-    std::copy(fbsData->data()->begin(), fbsData->data()->end(), data->begin());
+    const auto fbsBytes = fbsData->data();
+
+    if (fbsBytes == nullptr)
+    {
+        data->clear();
+        return;
+    }
+
+    data->assign(fbsBytes->begin(), fbsBytes->end());
 }
 }  // namespace CubbyFlow

--- a/Tests/ManualTests/ManualTests.hpp
+++ b/Tests/ManualTests/ManualTests.hpp
@@ -32,7 +32,7 @@ inline void CreateDirectory(const std::string& dirName)
 #ifdef CUBBYFLOW_WINDOWS
         _mkdir(partialDir.c_str());
 #else
-        mkdir(partialDir.c_str(), S_IRWXU | S_IRWXG | S_IRWXO);
+        mkdir(partialDir.c_str(), S_IRWXU);
 #endif
     }
 }

--- a/Tests/UnitTests/Array1Tests.cpp
+++ b/Tests/UnitTests/Array1Tests.cpp
@@ -140,3 +140,34 @@ TEST(Array1, ParallelForEachIndex)
         EXPECT_EQ(ans, arr1[i]);
     });
 }
+
+TEST(Array1, DeserializeValidatesData)
+{
+    const std::vector<uint8_t> emptyBuffer;
+    const std::vector<uint8_t> truncatedBuffer(1);
+    Array1<double> invalidResult(1, 42.0);
+
+    EXPECT_THROW(Deserialize(emptyBuffer, &invalidResult),
+                 std::invalid_argument);
+    EXPECT_THROW(Deserialize(truncatedBuffer, &invalidResult),
+                 std::invalid_argument);
+    ASSERT_EQ(1u, invalidResult.Length());
+    EXPECT_DOUBLE_EQ(42.0, invalidResult[0]);
+
+    std::vector<uint8_t> buffer;
+    Serialize(static_cast<const uint8_t*>(nullptr), 0, &buffer);
+
+    Array1<double> emptyResult(1, 42.0);
+    Deserialize(buffer, &emptyResult);
+
+    EXPECT_EQ(0u, emptyResult.Length());
+
+    const uint8_t byte = 0;
+    Serialize(&byte, sizeof(byte), &buffer);
+
+    Array1<double> array(1, 42.0);
+
+    EXPECT_THROW(Deserialize(buffer, &array), std::invalid_argument);
+    ASSERT_EQ(1u, array.Length());
+    EXPECT_DOUBLE_EQ(42.0, array[0]);
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectKey=CubbyFlow
+sonar.projectKey=utilForever_CubbyFlow
+sonar.organization=utilforever-github
 sonar.projectName=CubbyFlow
 sonar.projectVersion=0.72
 
@@ -6,10 +7,10 @@ sonar.projectVersion=0.72
 #   Meta-data for the project
 # =====================================================
 
-sonar.links.homepage=https://github.com/CubbyFlow/CubbyFlow
-sonar.links.ci=https://travis-ci.org/CubbyFlow/CubbyFlow
-sonar.links.scm=https://github.com/CubbyFlow/CubbyFlow
-sonar.links.issue=https://github.com/CubbyFlow/CubbyFlow/issues
+sonar.links.homepage=https://github.com/utilForever/CubbyFlow
+sonar.links.ci=https://travis-ci.org/utilForever/CubbyFlow
+sonar.links.scm=https://github.com/utilForever/CubbyFlow
+sonar.links.issue=https://github.com/utilForever/CubbyFlow/issues
 
 # =====================================================
 #   Properties that will be shared amongst all modules
@@ -20,6 +21,5 @@ sonar.sources=.
 sonar.exclusions=README.md,3RD-PARTY.md,Dockerfile,setup.py,Documents/**,Examples/**,Libraries/**,Medias/**,Resources/**,Scripts/**,Sources/Core/Flatbuffers/generated/**,deps/**
 
 # Properties specific to the C/C++ analyzer:
-sonar.cfamily.threads=2
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=build/Tests/UnitTests/CMakeFiles


### PR DESCRIPTION
This revision includes:
- Restore SonarCloud (Closes #141)
  - Configure SonarCloud automatic analysis
  - Use safe Bash conditionals for CUDA setup
  - Make logger buffer mutation explicit
  - Replace async task dispatch with explicit execution
  - Make Vector3 trivially copyable
  - Validate serialized array data
  - Restrict manual test output permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened FlatBuffer serialization/deserialization validation for empty, malformed, truncated, and size-mismatched payloads, throwing `std::invalid_argument` on bad inputs and safely clearing/handling outputs.
  * Preserved destination data when deserialization fails.
  * Improved CUDA environment/toolchain validation in the installer script.
  * Restricted non-Windows manual test directory permissions to the current user.
* **Improvements**
  * Updated logging stream chaining behavior.
* **Refactor**
  * Simplified fixed-size `Matrix` copy/move special member implementations.
* **Chores**
  * Updated SonarCloud configuration.
* **Tests**
  * Added unit tests covering deserialization failure modes and destination preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->